### PR TITLE
Create missing Equipment FTA Partial

### DIFF
--- a/app/views/assets/_equipment_fta.html.haml
+++ b/app/views/assets/_equipment_fta.html.haml
@@ -1,0 +1,1 @@
+= format_field("Funding Type", @asset.fta_funding_type)


### PR DESCRIPTION
Asset/_details.html.haml calls 'render #{asset_type.name}_fta' or similar and, while the corresponding file already existed for facilities and vehicles, it didn't exist for Equipment.  This adds the file for equipment.

This is created in transam_transit because FtaFundingType is added to asset from the TransamTransitAsset module in this engine.