### PR TITLE
Update disposition form

### DIFF
--- a/app/models/disposition_update_event.rb
+++ b/app/models/disposition_update_event.rb
@@ -19,8 +19,8 @@ class DispositionUpdateEvent < AssetEvent
 
   validates :disposition_type,      :presence => true
   validates :sales_proceeds,        :presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}
-  validates :mileage_at_disposition,:presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}, if: Proc.new { |event| event.asset.asset_type == "Vehicle" || event.asset.asset_type.class_name == "SupportVehicle" }
-  validates :comments,               :presence => true, if: Proc.new { |event| event.disposition_type.name == "Other" }
+  validates :mileage_at_disposition,:presence => { :message => "Cannot be blank for Revenue Vehicles or Support Vehicles" }, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}, if: Proc.new { |event| event.asset.asset_type == "Vehicle" || event.asset.asset_type.class_name == "SupportVehicle" }
+  validates :comments,               :presence => { :message => 'Cannot be blank if you selected "Other" as the Disposition Type' }, if: Proc.new { |event| event.disposition_type.name == "Other" }
   #validates :new_owner_name,      :presence => true
   #validates :address1,            :presence => true
   #validates :city,                :presence => true

--- a/app/models/disposition_update_event.rb
+++ b/app/models/disposition_update_event.rb
@@ -20,6 +20,7 @@ class DispositionUpdateEvent < AssetEvent
   validates :disposition_type,      :presence => true
   validates :sales_proceeds,        :presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}
   validates :mileage_at_disposition,:presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}, if: Proc.new { |event| event.asset.asset_type == "Vehicle" || event.asset.asset_type.class_name == "SupportVehicle" }
+  validates :comments,               :presence => true, if: Proc.new { |event| event.disposition_type.name == "Other" }
   validates :age_at_disposition,    :presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}
   #validates :new_owner_name,      :presence => true
   #validates :address1,            :presence => true

--- a/app/models/disposition_update_event.rb
+++ b/app/models/disposition_update_event.rb
@@ -39,13 +39,7 @@ class DispositionUpdateEvent < AssetEvent
     :disposition_type_id,
     :sales_proceeds,
     :age_at_disposition,
-    :mileage_at_disposition,
-    :new_owner_name,
-    :address1,
-    :address2,
-    :city,
-    :state,
-    :zip
+    :mileage_at_disposition
   ]
 
   #------------------------------------------------------------------------------
@@ -84,10 +78,6 @@ class DispositionUpdateEvent < AssetEvent
 
   def get_update
     "#{disposition_type} on #{event_date}"
-  end
-
-  def calculate_age_at_disposition
-    event_date.year - asset.purchase_date.year
   end
 
   #------------------------------------------------------------------------------

--- a/app/models/disposition_update_event.rb
+++ b/app/models/disposition_update_event.rb
@@ -21,7 +21,6 @@ class DispositionUpdateEvent < AssetEvent
   validates :sales_proceeds,        :presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}
   validates :mileage_at_disposition,:presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}, if: Proc.new { |event| event.asset.asset_type == "Vehicle" || event.asset.asset_type.class_name == "SupportVehicle" }
   validates :comments,               :presence => true, if: Proc.new { |event| event.disposition_type.name == "Other" }
-  validates :age_at_disposition,    :presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}
   #validates :new_owner_name,      :presence => true
   #validates :address1,            :presence => true
   #validates :city,                :presence => true
@@ -85,6 +84,10 @@ class DispositionUpdateEvent < AssetEvent
 
   def get_update
     "#{disposition_type} on #{event_date}"
+  end
+
+  def calculate_age_at_disposition
+    event_date.year - asset.purchase_date.year
   end
 
   #------------------------------------------------------------------------------

--- a/app/models/disposition_update_event.rb
+++ b/app/models/disposition_update_event.rb
@@ -1,0 +1,103 @@
+#
+# Disposition update event. This is event type is required for
+# all implementations
+#
+class DispositionUpdateEvent < AssetEvent
+
+  # Callbacks
+  after_initialize :set_defaults
+
+  # Associations
+
+  # Alias current_mileage to mileage_disposition so we can re-use the existing attribute
+  alias_attribute :mileage_at_disposition,  :current_mileage
+  # Alias age_at_disposition to replacement_year so we can re-use the existing attribute
+  alias_attribute :age_at_disposition,      :replacement_year
+
+  # Disposition of the asset
+  belongs_to  :disposition_type
+
+  validates :disposition_type,      :presence => true
+  validates :sales_proceeds,        :presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}
+  validates :mileage_at_disposition,:presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}, if: Proc.new { |event| event.asset.asset_type == "Vehicle" || event.asset.asset_type.class_name == "SupportVehicle" }
+  validates :age_at_disposition,    :presence => true, :numericality => {:only_integer => true, :greater_than_or_equal_to => 0}
+  #validates :new_owner_name,      :presence => true
+  #validates :address1,            :presence => true
+  #validates :city,                :presence => true
+  #validates :state,               :presence => true
+  #validates :zip,                 :presence => true
+  #validates_format_of :zip,       :with => /\A\d{5}([\-]?\d{4})?\z/
+
+  #------------------------------------------------------------------------------
+  # Scopes
+  #------------------------------------------------------------------------------
+  # set the default scope
+  default_scope { where(:asset_event_type_id => AssetEventType.find_by_class_name(self.name).id).order(:event_date, :created_at) }
+
+  # List of hash parameters allowed by the controller
+  FORM_PARAMS = [
+    :disposition_type_id,
+    :sales_proceeds,
+    :age_at_disposition,
+    :mileage_at_disposition,
+    :new_owner_name,
+    :address1,
+    :address2,
+    :city,
+    :state,
+    :zip
+  ]
+
+  #------------------------------------------------------------------------------
+  #
+  # Class Methods
+  #
+  #------------------------------------------------------------------------------
+
+  def self.allowable_params
+    FORM_PARAMS
+  end
+
+  #returns the asset event type for this type of event
+  def self.asset_event_type
+    AssetEventType.find_by_class_name(self.name)
+  end
+
+  #------------------------------------------------------------------------------
+  #
+  # Instance Methods
+  #
+  #------------------------------------------------------------------------------
+
+  # Override setters to remove any extraneous formats from the number strings eg $, etc.
+  def sales_proceeds=(num)
+    self[:sales_proceeds] = sanitize_to_int(num)
+  end
+
+  def age_at_disposition=(num)
+    self[:replacement_year] = sanitize_to_int(num)
+  end
+
+  def mileage_at_disposition=(num)
+    self[:current_mileage] = sanitize_to_int(num)
+  end
+
+  def get_update
+    "#{disposition_type} on #{event_date}"
+  end
+
+  #------------------------------------------------------------------------------
+  #
+  # Protected Methods
+  #
+  #------------------------------------------------------------------------------
+  protected
+
+  # Set resonable defaults for a new condition update event
+  def set_defaults
+    super
+    self.disposition_type ||= asset.disposition_type
+    self.asset_event_type ||= AssetEventType.find_by_class_name(self.name)
+  end
+
+end

--- a/app/views/asset_events/_disposition_update_event_form.html.haml
+++ b/app/views/asset_events/_disposition_update_event_form.html.haml
@@ -27,9 +27,6 @@
             %i.fa.fa-usd
           = f.input :sales_proceeds, :class => 'form-control', :input_html => { :min => 0 }, :label => false
 
-  / = label_tag(:organization, "Organization Transferred to", :class => 'control-label')
-  / = select_tag(:organization, options_for_select(Organization.where.not(id: @asset.organization.id).map { |org| [org.name, org.id] }), :class => 'form-control form-group', :label => "New Organization", :include_blank => "Out of State")
-
   = f.input :comments, :input_html => { :rows => 6 }, :placeholder => "Enter any additional comments..."
   .form-group
     = f.button :submit, "Record disposition", :class => 'btn btn-primary'

--- a/app/views/asset_events/_disposition_update_event_form.html.haml
+++ b/app/views/asset_events/_disposition_update_event_form.html.haml
@@ -19,7 +19,7 @@
           = f.input :sales_proceeds, :class => 'form-control', :input_html => { :min => 0 }, :label => false
 
       .col-xs-6
-        = f.input :mileage_at_disposition, :as => :integer, :label => "Mileage at disposition", :input_html => { :min => 0 }, :input_html => { :value => @asset.reported_mileage }
+        = f.input :mileage_at_disposition, :as => :integer, :label => "Mileage at disposition", :input_html => { :min => 0 }, :input_html => { :value => @asset.reported_mileage }, :required => true
     - else
       .col-xs-12
         = f.input :sales_proceeds, :wrapper => :vertical_prepend, :label => "Funds Received" do

--- a/app/views/asset_events/_disposition_update_event_form.html.haml
+++ b/app/views/asset_events/_disposition_update_event_form.html.haml
@@ -19,7 +19,7 @@
           = f.input :sales_proceeds, :class => 'form-control', :input_html => { :min => 0 }, :label => false
 
       .col-xs-6
-        = f.input :mileage_at_disposition, :as => :integer, :label => "Mileage at disposition", :input_html => { :min => 0, :value => @asset.reported_mileage }
+        = f.input :mileage_at_disposition, :as => :integer, :label => "Mileage at disposition", :input_html => { :min => 0 }, :input_html => { :value => @asset.reported_mileage }
     - else
       .col-xs-12
         = f.input :sales_proceeds, :wrapper => :vertical_prepend, :label => "Funds Received" do
@@ -27,28 +27,9 @@
             %i.fa.fa-usd
           = f.input :sales_proceeds, :class => 'form-control', :input_html => { :min => 0 }, :label => false
 
-  = label_tag(:organization, "Organization Transferred to", :class => 'control-label')
-  = select_tag(:organization, options_for_select(Organization.where.not(id: @asset.organization.id).map { |org| [org.name, org.id] }), :class => 'form-control form-group', :label => "New Organization", :include_blank => "Out of State")
+  / = label_tag(:organization, "Organization Transferred to", :class => 'control-label')
+  / = select_tag(:organization, options_for_select(Organization.where.not(id: @asset.organization.id).map { |org| [org.name, org.id] }), :class => 'form-control form-group', :label => "New Organization", :include_blank => "Out of State")
 
-  .row
-    .col-sm-6
-      = f.input :city
-    .col-sm-3
-      = f.input :state, :as => :select, :collection => Country['US'].states, :include_blank => false
-    .col-sm-3
-      = f.input :zip
   = f.input :comments, :input_html => { :rows => 6 }, :placeholder => "Enter any additional comments..."
   .form-group
     = f.button :submit, "Record disposition", :class => 'btn btn-primary'
-
-:javascript
-  $.validator.addMethod(
-    "regex",
-    function(value, element, regexp) {
-      var re = new RegExp(regexp);
-      return this.optional(element) || re.test(value);
-    },
-    "Must be a valid zip code."
-  );
-
-  $("input[name='asset_event[zip]']").rules("add", { regex: /^\d{5}([\-]?\d{4})?$/ })

--- a/app/views/asset_events/_disposition_update_event_form.html.haml
+++ b/app/views/asset_events/_disposition_update_event_form.html.haml
@@ -1,0 +1,54 @@
+= render :layout => "update_event_form" do |f|
+
+
+  .row
+    .col-xs-6
+      = f.input :event_date, :label => 'Date of Disposition', :wrapper => :vertical_append do
+        = f.input_field :event_date, :as => :string, :class => 'form-control datepicker', :data => {'behavior' => 'datepicker'}, :value => format_as_date(f.object.event_date)
+        %span.input-group-addon
+          %i.fa.fa-calendar
+    .col-xs-6
+      = f.association :disposition_type, :label => "Disposition Type", :include_blank => false
+
+  .row
+    - if @asset.asset_type.class_name == "Vehicle" || @asset.asset_type.class_name == "SupportVehicle"
+      .col-xs-6
+        = f.input :sales_proceeds, :wrapper => :vertical_prepend, :label => "Sales Proceeds" do
+          %span.input-group-addon
+            %i.fa.fa-usd
+          = f.input :sales_proceeds, :class => 'form-control', :input_html => { :min => 0 }, :label => false
+
+      .col-xs-6
+        = f.input :mileage_at_disposition, :as => :integer, :label => "Mileage at disposition", :input_html => { :min => 0, :value => @asset.reported_mileage }
+    - else
+      .col-xs-12
+        = f.input :sales_proceeds, :wrapper => :vertical_prepend, :label => "Funds Received" do
+          %span.input-group-addon
+            %i.fa.fa-usd
+          = f.input :sales_proceeds, :class => 'form-control', :input_html => { :min => 0 }, :label => false
+
+  = label_tag(:organization, "Organization Transferred to", :class => 'control-label')
+  = select_tag(:organization, options_for_select(Organization.where.not(id: @asset.organization.id).map { |org| [org.name, org.id] }), :class => 'form-control form-group', :label => "New Organization", :include_blank => "Out of State")
+
+  .row
+    .col-sm-6
+      = f.input :city
+    .col-sm-3
+      = f.input :state, :as => :select, :collection => Country['US'].states, :include_blank => false
+    .col-sm-3
+      = f.input :zip
+  = f.input :comments, :input_html => { :rows => 6 }, :placeholder => "Enter any additional comments..."
+  .form-group
+    = f.button :submit, "Record disposition", :class => 'btn btn-primary'
+
+:javascript
+  $.validator.addMethod(
+    "regex",
+    function(value, element, regexp) {
+      var re = new RegExp(regexp);
+      return this.optional(element) || re.test(value);
+    },
+    "Must be a valid zip code."
+  );
+
+  $("input[name='asset_event[zip]']").rules("add", { regex: /^\d{5}([\-]?\d{4})?$/ })


### PR DESCRIPTION
This pull request makes the following changes to the disposition form.

1.  It removes several form fields.  In particular, it removes all of the fields related to the new owner and the new owner's address.

2.  It changes the form so that the user is only required to input the mileage at disposition if the asset is a vehicle or support vehicle.

3.  It only requires the validation of mileage at disposition if the asset is a vehicle or support vehicle.

4.  If the user selects the "Other" disposition type, it requires the user to leave a comment.

Right now, the disposition form does not do anything related to requests for early disposition.  It also does not facilitate the transfer of assets from one organization to another in that it does not allow the user to select which organization he or she transferred the asset to.