### PR TITLE
Added reference to the javascript partial for this form at the bottom…

### DIFF
--- a/app/views/asset_events/_disposition_update_event_form.html.haml
+++ b/app/views/asset_events/_disposition_update_event_form.html.haml
@@ -30,3 +30,5 @@
   = f.input :comments, :input_html => { :rows => 6 }, :placeholder => "Enter any additional comments..."
   .form-group
     = f.button :submit, "Record disposition", :class => 'btn btn-primary'
+
+= render 'disposition_form_scripts'


### PR DESCRIPTION
… of the page. [#100510974]

The disposition form now uses a small script to add a client side validation for the comments section.  Transit has its own version of this form, and this pull request adds the partial that will load in the appropriate script to add the validation.  The script itself belongs in core.