### PR TITLE
Added fta_funding_type to the vehicle model's allowable params. [#102…

### DIFF
--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -20,9 +20,6 @@ class Vehicle < PassengerVehicle
   # Associations common to all Vehicles
   #------------------------------------------------------------------------------
 
-  #
-  belongs_to :policy_rule
-
   # each asset has a rebuild type
   belongs_to  :vehicle_rebuild_type
 

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -65,6 +65,7 @@ class Vehicle < PassengerVehicle
     :serial_number,
     :gross_vehicle_weight,
     :vehicle_rebuild_type_id,
+    :fta_funding_funding_type_id,
     :vehicle_usage_code_ids => []
   ]
 

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -20,6 +20,9 @@ class Vehicle < PassengerVehicle
   # Associations common to all Vehicles
   #------------------------------------------------------------------------------
 
+  #
+  belongs_to :policy_rule
+
   # each asset has a rebuild type
   belongs_to  :vehicle_rebuild_type
 
@@ -65,7 +68,7 @@ class Vehicle < PassengerVehicle
     :serial_number,
     :gross_vehicle_weight,
     :vehicle_rebuild_type_id,
-    :fta_funding_funding_type_id,
+    :fta_funding_type_id,
     :vehicle_usage_code_ids => []
   ]
 


### PR DESCRIPTION
…365810].

This code fix allows the asset to get past the strong params, but we cannot save vehicles yet because we still need to make fixes related to the changes in the policy rules.