### PR TITLE
Policy subtype form

### DIFF
--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -8,6 +8,10 @@
   :file => :vertical_file_input,
   :boolean => :vertical_boolean}) do |f|
 
+  - mileage_vehicles = ["Vehicle", "SupportVehicle"]
+  - all_vehicles = ["Vehicle", "SupportVehicle", "Locomotive", "RailCar"]
+  - subtype_class_name = @rule.asset_subtype.asset_type.class_name
+
   = f.input :id, :as => :hidden
 
   %fieldset
@@ -30,7 +34,7 @@
         = f.input :replace_with_new
         = f.input :replace_with_leased
 
-      -if @rule.asset_subtype.asset_type.class_name == "Vehicle" || @rule.asset_subtype.asset_type.class_name == "SupportVehicle"
+      -if mileage_vehicles.include?(subtype_class_name)
         .col-xs-3.mileage
           = f.input :fuel_type_id, :collection => FuelType.active.collect{|x| [x.name, x.id]}
         .col-xs-3.mileage
@@ -43,7 +47,7 @@
 
       .col-xs-3.vehicles.station
         = f.input :purchase_replacement_code
-      -if @rule.asset_subtype.asset_type.class_name == "Vehicle" || @rule.asset_subtype.asset_type.class_name == "SupportVehicle"
+      -if all_vehicles.include?(subtype_class_name)
         .col-xs-3.vehicles
           = f.input :purchase_expansion_code
         .col-xs-3.vehicles
@@ -52,7 +56,7 @@
         = f.input :lease_expansion_code
       .col-xs-3.vehicles.station
         = f.input :engineering_design_code
-      -unless @rule.asset_subtype.asset_type.class_name == "Vehicle" || @rule.asset_subtype.asset_type.class_name == "SupportVehicle"
+      -unless all_vehicles.include?(subtype_class_name)
         .col-xs-3.station
           = f.input :construction_code
 
@@ -132,23 +136,5 @@
     } else {
       $("label[for = policy_asset_subtype_rule_replacement_cost]").html('<abbr title="required">*</abbr> Replacement Cost ');
       $('.leased').hide().find(':input').val('');
-    }
-  };
-
-
-  function show_asset_appropriate_fields(){
-
-    // Show the Mileage and Fuel if a Vehicle or Support Vehicle
-    if (asset_class === "Vehicle" || asset_class === "SupportVehicle"){
-      $('.mileage').show();
-    } else {
-      $('.mileage').hide();
-    }
-
-    // These asset types appear to use the same set of ALI codes
-    if (asset_class === "TransitFacility" || asset_class === "Equipment"){
-      $('.station').show();
-    } else {
-      $('.station').hide();
     }
   };

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -96,17 +96,6 @@
     replace_with_leased_action(checked);
 
     show_asset_appropriate_fields();
-
-    //Event handlers
-    $('#policy_asset_subtype_rule_replace_with_new').on('click', function() {
-      var checked = $(this).is(':checked');
-      replace_with_new_action(checked);
-    });
-    $('#policy_asset_subtype_rule_replace_with_leased').on('click', function() {
-      var checked = $(this).is(':checked');
-      replace_with_leased_action(checked);
-    });
-
     subtype_selector.on('change', function() {
       show_asset_appropriate_fields();
     });
@@ -124,8 +113,10 @@
 
   function replace_with_new_action(checked) {
     if (checked) {
+      console.log("new is checked")
       $('.used').hide().find(':input').val('');
     } else {
+      console.log("new is not checked.")
       $('.used').fadeIn();
     }
   };
@@ -138,6 +129,17 @@
       $('.leased').hide().find(':input').val('').attr('disabled', true);
     }
   };
+
+  $('#policy_asset_subtype_rule_replace_with_new').on('click', function() {
+      var checked = $(this).is(':checked');
+      replace_with_new_action(checked);
+    });
+
+
+  $('#policy_asset_subtype_rule_replace_with_leased').on('click', function() {
+      var checked = $(this).is(':checked');
+      replace_with_leased_action(checked);
+    });
 
 
   function show_asset_appropriate_fields(){

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -95,10 +95,6 @@
     checked = $('#policy_asset_subtype_rule_replace_with_leased').is(':checked');
     replace_with_leased_action(checked);
 
-    show_asset_appropriate_fields();
-    subtype_selector.on('change', function() {
-      show_asset_appropriate_fields();
-    });
   });
 
   // validate the form before submittal
@@ -140,19 +136,3 @@
       var checked = $(this).is(':checked');
       replace_with_leased_action(checked);
     });
-
-
-  function show_asset_appropriate_fields(){
-    // Show the Mileage and Fuel if a Vehicle or Support Vehicle
-    if (asset_class === "Vehicle" || asset_class === "SupportVehicle"){
-      $('.mileage').show();
-    } else {
-      $('.mileage').hide();
-    }
-    // These asset types appear to use the same set of ALI codes
-    if (asset_class === "TransitFacility" || asset_class === "Equipment"){
-      $('.station').show();
-    } else {
-      $('.station').hide();
-    }
-  };

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -123,7 +123,7 @@
   function replace_with_leased_action(checked) {
     if (checked) {
       $("label[for = policy_asset_subtype_rule_replacement_cost]").html('<abbr title="required">*</abbr> Lease Cost ');
-      $('.leased').attr('disabled', false).fadeIn();
+      $('.leased').fadeIn().find(':input').val('').attr('disabled', false);
     } else {
       $("label[for = policy_asset_subtype_rule_replacement_cost]").html('<abbr title="required">*</abbr> Replacement Cost ');
       $('.leased').hide().find(':input').val('').attr('disabled', true);

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -89,6 +89,7 @@
   var asset_class = "#{@rule.asset_subtype.asset_type.class_name}";
 
   $(document).ready(function() {
+    console.log('start')
     // Setup form state
     var checked = $('#policy_asset_subtype_rule_replace_with_new').is(':checked');
     replace_with_new_action(checked);
@@ -99,6 +100,7 @@
 
     //Event handlers
     $('#policy_asset_subtype_rule_replace_with_new').on('click', function() {
+      console.log('click')
       var checked = $(this).is(':checked');
       replace_with_new_action(checked);
     });
@@ -132,9 +134,25 @@
   function replace_with_leased_action(checked) {
     if (checked) {
       $("label[for = policy_asset_subtype_rule_replacement_cost]").html('<abbr title="required">*</abbr> Lease Cost ');
-      $('.leased').fadeIn();
+      $('.leased').attr('disabled', false).fadeIn();
     } else {
       $("label[for = policy_asset_subtype_rule_replacement_cost]").html('<abbr title="required">*</abbr> Replacement Cost ');
-      $('.leased').hide().find(':input').val('');
+      $('.leased').hide().find(':input').val('').attr('disabled', true);
+    }
+  };
+
+
+  function show_asset_appropriate_fields(){
+    // Show the Mileage and Fuel if a Vehicle or Support Vehicle
+    if (asset_class === "Vehicle" || asset_class === "SupportVehicle"){
+      $('.mileage').show();
+    } else {
+      $('.mileage').hide();
+    }
+    // These asset types appear to use the same set of ALI codes
+    if (asset_class === "TransitFacility" || asset_class === "Equipment"){
+      $('.station').show();
+    } else {
+      $('.station').hide();
     }
   };

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -53,12 +53,12 @@
         .col-xs-3.vehicles
           = f.input :lease_replacement_code
       .col-xs-3.vehicles.station
-        = f.input :lease_expansion_code
+        = f.input :lease_expansion_code, required: true, :input_html => {:minlength => 8 , maxlength: 8}
       .col-xs-3.vehicles.station
-        = f.input :engineering_design_code
+        = f.input :engineering_design_code, required: true, :input_html => {:minlength => 8 , maxlength: 8}
       -unless all_vehicles.include?(subtype_class_name)
         .col-xs-3.station
-          = f.input :construction_code
+          = f.input :construction_code, required: true, :input_html => {:minlength => 8 , maxlength: 8}
 
   %fieldset
     %legend Rehabilitation

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -109,11 +109,9 @@
 
   function replace_with_new_action(checked) {
     if (checked) {
-      console.log("new is checked")
-      $('.used').hide().find(':input').val('');
+      $('.used').hide().find(':input').val('').attr('disabled', true).removeClass('required');
     } else {
-      console.log("new is not checked.")
-      $('.used').fadeIn();
+      $('.used').fadeIn().find(':input').val('').attr('disabled', false).addClass('required');
     }
   };
   function replace_with_leased_action(checked) {

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -89,7 +89,6 @@
   var asset_class = "#{@rule.asset_subtype.asset_type.class_name}";
 
   $(document).ready(function() {
-    console.log('start')
     // Setup form state
     var checked = $('#policy_asset_subtype_rule_replace_with_new').is(':checked');
     replace_with_new_action(checked);
@@ -100,7 +99,6 @@
 
     //Event handlers
     $('#policy_asset_subtype_rule_replace_with_new').on('click', function() {
-      console.log('click')
       var checked = $(this).is(':checked');
       replace_with_new_action(checked);
     });

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -30,29 +30,31 @@
         = f.input :replace_with_new
         = f.input :replace_with_leased
 
-    .row
-      .col-xs-3.mileage
-        = f.input :fuel_type_id, :collection => FuelType.active.collect{|x| [x.name, x.id]}
-      .col-xs-3.mileage
-        = f.input :min_service_life_miles, :input_html => { min: 0 }
+      -if @rule.asset_subtype.asset_type.class_name == "Vehicle" || @rule.asset_subtype.asset_type.class_name == "SupportVehicle"
+        .col-xs-3.mileage
+          = f.input :fuel_type_id, :collection => FuelType.active.collect{|x| [x.name, x.id]}
+        .col-xs-3.mileage
+          = f.input :min_service_life_miles, :input_html => { min: 0 }
       .col-xs-3.used
         = f.input :min_used_purchase_service_life_months, :label => "Min used service life", :input_html => { min: 48 }
       .col-xs-3.leased
         = f.input :lease_length_months, :input_html => { min: 0 }
 
-    .row
+
       .col-xs-3.vehicles.station
         = f.input :purchase_replacement_code
-      .col-xs-3.vehicles
-        = f.input :purchase_expansion_code
-      .col-xs-3.vehicles
-        = f.input :lease_replacement_code
+      -if @rule.asset_subtype.asset_type.class_name == "Vehicle" || @rule.asset_subtype.asset_type.class_name == "SupportVehicle"
+        .col-xs-3.vehicles
+          = f.input :purchase_expansion_code
+        .col-xs-3.vehicles
+          = f.input :lease_replacement_code
       .col-xs-3.vehicles.station
         = f.input :lease_expansion_code
       .col-xs-3.vehicles.station
         = f.input :engineering_design_code
-      .col-xs-3.station
-        = f.input :construction_code
+      -unless @rule.asset_subtype.asset_type.class_name == "Vehicle" || @rule.asset_subtype.asset_type.class_name == "SupportVehicle"
+        .col-xs-3.station
+          = f.input :construction_code
 
   %fieldset
     %legend Rehabilitation

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -119,10 +119,11 @@
   function replace_with_leased_action(checked) {
     if (checked) {
       $("label[for = policy_asset_subtype_rule_replacement_cost]").html('<abbr title="required">*</abbr> Lease Cost ');
-      $('.leased').fadeIn().find(':input').val('').attr('disabled', false);
+      $("label[for = policy_asset_subtype_rule_lease_length_months]").html('<abbr title="required">*</abbr> Lease Length Months ');
+      $('.leased').fadeIn().find(':input').val('').attr('disabled', false).addClass("required");
     } else {
       $("label[for = policy_asset_subtype_rule_replacement_cost]").html('<abbr title="required">*</abbr> Replacement Cost ');
-      $('.leased').hide().find(':input').val('').attr('disabled', true);
+      $('.leased').hide().find(':input').val('').attr('disabled', true).removeClass('required');
     }
   };
 

--- a/app/views/policies/_asset_subtype_rule_form.html.haml
+++ b/app/views/policies/_asset_subtype_rule_form.html.haml
@@ -19,7 +19,7 @@
     .row
       .col-xs-3
         = f.input :min_service_life_months, :wrapper=> :vertical_append, :label => "Min service life" do
-          = f.input_field :min_service_life_months, :class => "form-control", :input_html => { min: 1}
+          = f.input_field :min_service_life_months, :class => "form-control", min: @rule.minimum_value(:min_service_life_months, 1)
           %span.input-group-addon
             %i.fa Mo
 
@@ -27,7 +27,7 @@
         = f.input :replacement_cost, :wrapper=> :vertical_prepend  do
           %span.input-group-addon
             %i.fa.fa-usd
-          = f.input_field :replacement_cost, :class => "form-control", :min => 0
+          = f.input_field :replacement_cost, :class => "form-control", :min => @rule.minimum_value(:replacement_cost)
       .col-xs-3
         = f.input :cost_fy_year, :collection => get_fiscal_years
       .col-xs-3
@@ -38,11 +38,11 @@
         .col-xs-3.mileage
           = f.input :fuel_type_id, :collection => FuelType.active.collect{|x| [x.name, x.id]}
         .col-xs-3.mileage
-          = f.input :min_service_life_miles, :input_html => { min: 0 }
+          = f.input :min_service_life_miles, :input_html => { min: @rule.minimum_value(:min_service_life_miles) }
       .col-xs-3.used
-        = f.input :min_used_purchase_service_life_months, :label => "Min used service life", :input_html => { min: 48 }
+        = f.input :min_used_purchase_service_life_months, :label => "Min used service life", :input_html =>{ min:  @rule.minimum_value(:min_used_purchase_service_life_months, 48) }
       .col-xs-3.leased
-        = f.input :lease_length_months, :input_html => { min: 0 }
+        = f.input :lease_length_months, :input_html => { min: @rule.minimum_value(:lease_length_months) }
 
 
       .col-xs-3.vehicles.station
@@ -65,16 +65,16 @@
 
     .row
       .col-xs-3
-        = f.input :rehabilitation_service_month, :input_html => { min: 0 }
+        = f.input :rehabilitation_service_month, :input_html => { min: @rule.minimum_value(:rehabilitation_service_month) }
       .col-xs-3
         = f.input :rehabilitation_cost, :wrapper=> :vertical_prepend  do
           %span.input-group-addon
             %i.fa.fa-usd
-          = f.input_field :rehabilitation_cost, :class => "form-control", :min => 0
+          = f.input_field :rehabilitation_cost, :class => "form-control", :min => @rule.minimum_value(:rehabilitation_cost)
       .col-xs-3
-        = f.input :extended_service_life_months, :input_html => { min: 0 }
+        = f.input :extended_service_life_months, :input_html => { :min => @rule.minimum_value(:extended_service_life_months) }
       .col-xs-3.mileage
-        = f.input :extended_service_life_miles, :input_html => { min: 0 }
+        = f.input :extended_service_life_miles, :input_html => { :min => @rule.minimum_value(:extended_service_life_miles) }
 
     .row
       .col-xs-3.ali-code.vehicles.station


### PR DESCRIPTION
1.  This branch still has a bug in it.  We have event logic for changing the form fields based upon whether or not the "Purchase Leased" box is checked, but that javascript is not triggering when the user clicks on that check box.  So, we cannot merge this in unless you can spot some simple error in the javascript.

2.  The form no longer renders fields that are irrelevant to the particular subtype.

3.  The form now includes html 5 validations on several of the ali codes so that the user is less likely to submit invalid data.

4.  The form fields are not segmented into rows right now because not rendering or hiding those form fields would create white space.  I can go back and add back in the rows, if you think that is necessary.