### PR TITLE
Add validate_engine_seeds rake task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -383,13 +383,6 @@ end
 
 table_name = 'asset_subtypes'
 puts "  Loading #{table_name}"
-if is_mysql
-  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name};")
-elsif is_sqlite
-  ActiveRecord::Base.connection.execute("DELETE FROM #{table_name};")
-else
-  ActiveRecord::Base.connection.execute("TRUNCATE #{table_name} RESTART IDENTITY;")
-end
 data = eval(table_name)
 data.each do |row|
   x = AssetSubtype.new(row.except(:belongs_to, :type))

--- a/db/validate_rail_seeds_script.rb
+++ b/db/validate_rail_seeds_script.rb
@@ -1,0 +1,33 @@
+# Validates that engine rail seed data has loaded as expected
+# Added to the dynamically generated tmp/validate_seeds_data.rb file
+# Via the transam_{engine_name}:validate_engine_seeds rake task
+# Which should only be called from an app-level validate_engine_seeds rake task
+
+# Only added if the app-level environment has rail assets configured
+
+puts "      === Validating data from db/seeds/rail.seeds.rb ==="
+puts "        asset_types"
+asset_types.each do |row|
+  row_does_not_exist = AssetType.find_by(row).nil?
+  row_is_not_unique = AssetType.where(row).count > 1
+
+  puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+  puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+
+  # Skip id check since this is a merge_table
+end
+
+puts "        asset_subtypes"
+asset_subtypes.each do |row|
+  filtered_row = row.except(:belongs_to, :type)
+  filtered_row[:asset_type] = AssetType.where(:name => row[:type]).first
+  row_does_not_exist = AssetSubtype.find_by(filtered_row).nil?
+  row_is_not_unique = AssetSubtype.where(filtered_row).count > 1
+  asset_type_not_found = filtered_row[:asset_type].nil?
+
+  puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+  puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+  puts "          #{row.inspect} does not associate with an asset_type in this environment. Searched AssetType by name, using: #{row[:type]}." if asset_type_not_found
+
+  # Skip id check since this is a merge_table
+end

--- a/db/validate_seeds_script.rb
+++ b/db/validate_seeds_script.rb
@@ -1,5 +1,5 @@
 # Validates that engine seed data has loaded as expected
-# Added to the dynamically generated tmp/validate_seeds_data.rb file
+# Added to a dynamically generated validate_seeds_data.rb file
 # Via the transam_{engine_name}:validate_engine_seeds rake task
 # Which should only be called from an app-level validate_engine_seeds rake task
 

--- a/db/validate_seeds_script.rb
+++ b/db/validate_seeds_script.rb
@@ -1,0 +1,94 @@
+# Validates that engine seed data has loaded as expected
+# Added to the dynamically generated tmp/validate_seeds_data.rb file
+# Via the transam_{engine_name}:validate_engine_seeds rake task
+# Which should only be called from an app-level validate_engine_seeds rake task
+
+# Initialize the standard table name arrays in case they were never created
+lookup_tables ||= []
+replace_tables ||= []
+merge_tables ||= []
+
+# Validate rows from tables mentioned in the standard table name arrays
+%w{lookup_tables replace_tables merge_tables}.each do |table_name_array_name|
+
+  puts "    Validating #{table_name_array_name}"
+  table_name_array = eval(table_name_array_name)
+  table_name_array.each do |table_name|
+    puts "      #{table_name}"
+    data = eval(table_name)
+    klass = table_name.classify.constantize
+    data.each.with_index do |row, i|
+      row_does_not_exist = klass.find_by(row).nil?
+      row_is_not_unique = klass.where(row).count > 1
+
+      puts "        #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "        #{row.inspect} is not unique in this environment." if row_is_not_unique
+
+      # Skip this check with merge_tables, where id will vary
+      unless table_name_array_name == "merge_tables"
+        row_has_an_unexpected_id = false
+        unless row_does_not_exist || row_is_not_unique
+          row_has_an_unexpected_id = klass.find_by(row).id != i + 1
+        end
+
+        puts "        #{row.inspect} has an unexpected id in this environment. Got #{klass.find_by(row).id}. Expected #{i + 1}." if row_has_an_unexpected_id
+      end
+    end
+  end
+
+end
+
+# Validate specially handled tables (like reports)
+# NOTE: this will need to be updated by hand if we add tables or change logic
+
+puts "    Validating specially handled tables"
+
+puts "      asset_subtypes"
+asset_subtypes.each.with_index do |row, i|
+  filtered_row = row.except(:belongs_to, :type)
+  filtered_row[:asset_type] = AssetType.where(:name => row[:type]).first
+  row_does_not_exist = AssetSubtype.find_by(filtered_row).nil?
+  row_is_not_unique = AssetSubtype.where(filtered_row).count > 1
+  asset_type_not_found = filtered_row[:asset_type].nil?
+
+  row_has_an_unexpected_id = false
+  unless row_does_not_exist || row_is_not_unique
+    row_has_an_unexpected_id = AssetSubtype.find_by(filtered_row).id != i + 1
+  end
+
+  puts "        #{row.inspect} does not exist in this environment." if row_does_not_exist
+  puts "        #{row.inspect} is not unique in this environment." if row_is_not_unique
+  puts "        #{row.inspect} does not associate with an asset_type in this environment. Searched AssetType by name, using: #{row[:type]}." if asset_type_not_found
+  puts "        #{row.inspect} has an unexpected id in this environment. Got #{AssetSubtype.find_by(filtered_row).id}. Expected #{i + 1}." if row_has_an_unexpected_id
+end
+
+puts "      asset_subsystems"
+asset_subsystems.each.with_index do |row, i|
+  asset_type = AssetType.find_by(name: row[:asset_type])
+  adjusted_row = {name: row[:name], description: row[:name], active: true, code: row[:code], asset_type: asset_type}
+
+  row_does_not_exist = AssetSubsystem.find_by(adjusted_row).nil?
+  row_is_not_unique = AssetSubsystem.where(adjusted_row).count > 1
+  asset_type_not_found = adjusted_row[:asset_type].nil?
+
+  puts "        #{row.inspect} does not exist in this environment." if row_does_not_exist
+  puts "        #{row.inspect} is not unique in this environment." if row_is_not_unique
+  puts "        #{row.inspect} does not associate with an asset_type in this environment. Searched AssetType by name, using: #{row[:asset_type]}." if asset_type_not_found
+
+  # Skip id check since this is a merge_table
+end
+
+puts "      reports"
+reports.each.with_index do |row, i|
+  filtered_row = row.except(:belongs_to, :type)
+  filtered_row[:report_type] = ReportType.where(:name => row[:type]).first
+  row_does_not_exist = Report.find_by(filtered_row).nil?
+  row_is_not_unique = Report.where(filtered_row).count > 1
+  report_type_not_found = filtered_row[:report_type].nil?
+
+  puts "        #{row.inspect} does not exist in this environment." if row_does_not_exist
+  puts "        #{row.inspect} is not unique in this environment." if row_is_not_unique
+  puts "        #{row.inspect} does not associate with a report_type in this environment. Searched ReportType by name, using: #{row[:type]}." if report_type_not_found
+  
+  # Skip id check since this is a merge_table
+end

--- a/db/validate_seeds_script.rb
+++ b/db/validate_seeds_script.rb
@@ -51,15 +51,11 @@ asset_subtypes.each.with_index do |row, i|
   row_is_not_unique = AssetSubtype.where(filtered_row).count > 1
   asset_type_not_found = filtered_row[:asset_type].nil?
 
-  row_has_an_unexpected_id = false
-  unless row_does_not_exist || row_is_not_unique
-    row_has_an_unexpected_id = AssetSubtype.find_by(filtered_row).id != i + 1
-  end
-
   puts "        #{row.inspect} does not exist in this environment." if row_does_not_exist
   puts "        #{row.inspect} is not unique in this environment." if row_is_not_unique
   puts "        #{row.inspect} does not associate with an asset_type in this environment. Searched AssetType by name, using: #{row[:type]}." if asset_type_not_found
-  puts "        #{row.inspect} has an unexpected id in this environment. Got #{AssetSubtype.find_by(filtered_row).id}. Expected #{i + 1}." if row_has_an_unexpected_id
+
+  # Skip id check since this is a merge_table
 end
 
 puts "      asset_subsystems"

--- a/db/validate_team_ali_code_seeds_script.rb
+++ b/db/validate_team_ali_code_seeds_script.rb
@@ -1,0 +1,550 @@
+# Validates that engine team ali code seed data has loaded as expected
+# Added to the dynamically generated tmp/validate_seeds_data.rb file
+# Via the transam_{engine_name}:validate_engine_seeds rake task
+# Which should only be called from an app-level validate_engine_seeds rake task
+
+# NOTE: We don't get data dynamically from db/team_ali_code_seeds.rb, due to its complexity
+# So if that file changes, we'll need to update this file by hand
+
+puts "      === Validating data from db/seeds/team_ali_code_seeds.rb ==="
+
+# Validate the Scope/ALI tree
+
+# Start an id counter to check for unexpected ids
+id_count = 0
+
+# Validate the root nodes, these are top level categories
+puts "        team_ali_codes (root)"
+
+row_does_not_exist = TeamAliCode.find_by(:name => 'Capital',    :code => '1X.XX.XX').nil?
+row_is_not_unique = TeamAliCode.where(:name => 'Capital',    :code => '1X.XX.XX').count > 1
+
+row_has_an_unexpected_id = false
+id_count += 1
+unless row_does_not_exist || row_is_not_unique
+  row_has_an_unexpected_id = TeamAliCode.find_by(:name => 'Capital',    :code => '1X.XX.XX').id != id_count
+end
+
+puts "          #{{:name => 'Capital',    :code => '1X.XX.XX'}.inspect} does not exist in this environment." if row_does_not_exist
+puts "          #{{:name => 'Capital',    :code => '1X.XX.XX'}.inspect} is not unique in this environment." if row_is_not_unique
+puts "          #{{:name => 'Capital',    :code => '1X.XX.XX'}.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(:name => 'Capital',    :code => '1X.XX.XX').id}. Expected #{id_count}." if row_has_an_unexpected_id
+
+puts "        team_ali_codes (level 1)"
+
+level_1 = [
+  {:name => 'Bus',        :code => '11.XX.XX', :parent_code => '1X.XX.XX'},
+  {:name => 'Rail',       :code => '12.XX.XX', :parent_code => '1X.XX.XX'},
+  {:name => 'New Start',  :code => '14.XX.XX', :parent_code => '1X.XX.XX'}
+]
+level_1.each do |row|
+
+  filtered_row = row.except(:parent_code)
+  filtered_row[:parent_id] = TeamAliCode.find_by_code(row[:parent_code]).try(:id)
+  row_does_not_exist = TeamAliCode.find_by(filtered_row).nil?
+  row_is_not_unique = TeamAliCode.where(filtered_row).count > 1
+  parent_not_found = filtered_row[:parent_id].nil?
+
+  row_has_an_unexpected_id = false
+  id_count += 1
+  unless row_does_not_exist || row_is_not_unique
+    row_has_an_unexpected_id = TeamAliCode.find_by(filtered_row).id != id_count
+  end
+
+  puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+  puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+  puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{row[:parent_code]}." if parent_not_found
+  puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(filtered_row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+end
+
+# Level 2 for Bus and Fixed Guideways
+puts "        team_ali_codes (level 2)"
+
+level_2 = [
+  {:name => 'Revenue Rolling Stock',            :cat_code => 'XX.1X.XX'},
+  {:name => 'Transitway Lines',                 :cat_code => 'XX.2X.XX'},
+  {:name => 'Station Stops/Terminals',          :cat_code => 'XX.3X.XX'},
+  {:name => 'Support Facilities and Equipment', :cat_code => 'XX.4X.XX'},
+  {:name => 'Electrification Power Dist.',      :cat_code => 'XX.5X.XX'},
+  {:name => 'Signal & Communication',           :cat_code => 'XX.6X.XX'},
+  {:name => 'Other Capital Program Items.',     :cat_code => 'XX.7X.XX'},
+  {:name => 'State or Program Administration',  :cat_code => 'XX.80.00'},
+  {:name => 'Transit Enhancements',             :cat_code => 'XX.9X.XX'}
+]
+# Validate the second level for each of the bus and fixed guideway nodes
+%w{11.XX.XX 12.XX.XX}.each do |parent_code|
+  parent = TeamAliCode.find_by_code(parent_code)
+  level_2.each do |h|
+    pc = parent_code.split('.')[0]
+    tc = h[:cat_code].split('.')[1]
+    ac = h[:cat_code].split('.')[2]
+    code = "#{pc}.#{tc}.#{ac}"
+
+    row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+    row_does_not_exist = TeamAliCode.find_by(row).nil?
+    row_is_not_unique = TeamAliCode.where(row).count > 1
+    parent_not_found = row[:parent_id].nil?
+
+    row_has_an_unexpected_id = false
+    id_count += 1
+    unless row_does_not_exist || row_is_not_unique
+      row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+    end
+
+    puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+    puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+    puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+    puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+  end
+end
+
+# Third level for rolling stock only
+puts "        team_ali_codes (level 3)"
+
+level_3_rrs = [
+  {:name => 'Engineering & Design',     :cat_code => 'XX.11.XX'},
+  {:name => 'Purchase - Replacement',   :cat_code => 'XX.12.XX'},
+  {:name => 'Purchase - Expansion',     :cat_code => 'XX.13.XX'},
+  {:name => 'Rehabilitation/Rebuild',   :cat_code => 'XX.14.XX'},
+  {:name => 'Mid Life Rebuild (Rail)',  :cat_code => 'XX.15.XX'},
+  {:name => 'Lease - Replacement',      :cat_code => 'XX.16.XX'},
+  {:name => 'Lease - Expansion',        :cat_code => 'XX.18.XX'},
+  {:name => 'Vehicle Overhaul',         :cat_code => 'XX.17.00'}
+]
+# Validate the third level for each of the bus and fixed guideway nodes
+%w{11.1X.XX 12.1X.XX}.each do |parent_code|
+  parent = TeamAliCode.find_by_code(parent_code)
+  level_3_rrs.each do |h|
+    pc = parent_code.split('.')[0]
+    tc = h[:cat_code].split('.')[1]
+    ac = h[:cat_code].split('.')[2]
+    code = "#{pc}.#{tc}.#{ac}"
+    
+    row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+    row_does_not_exist = TeamAliCode.find_by(row).nil?
+    row_is_not_unique = TeamAliCode.where(row).count > 1
+    parent_not_found = row[:parent_id].nil?
+
+    row_has_an_unexpected_id = false
+    id_count += 1
+    unless row_does_not_exist || row_is_not_unique
+      row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+    end
+
+    puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+    puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+    puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+    puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+  end
+end
+
+# Third level for other
+level_3_oth = [
+  {:name => 'Engineering & Design',     :cat_code => 'XX.X1.XX'},
+  {:name => 'Acquisition',              :cat_code => 'XX.X2.XX'},
+  {:name => 'Construction',             :cat_code => 'XX.X3.XX'},
+  {:name => 'Rehab/Renovation',         :cat_code => 'XX.X4.XX'},
+  {:name => 'Lease',                    :cat_code => 'XX.X6.XX'}
+]
+
+# Validate the third level for each of the bus and fixed guideway nodes
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.2X.XX XX.3X.XX XX.4X.XX XX.5X.XX XX.6X.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_3_oth.each do |h|
+      tc1 = "#{tc.first}#{h[:cat_code].split('.')[1].last}"
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc1}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Third level for enhancements
+level_3_enh = [
+  {:name => 'Engineering & Design',     :cat_code => 'XX.X1.XX'},
+  {:name => 'Acquisition',              :cat_code => 'XX.X2.XX'},
+  {:name => 'Construction',             :cat_code => 'XX.X3.XX'},
+  {:name => 'Rehab/Renovation',         :cat_code => 'XX.X4.XX'},
+  {:name => 'Lease',                    :cat_code => 'XX.X5.XX'}
+]
+# Validate the third level for each of the bus and fixed guideway nodes for enhancements
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.9X.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_3_enh.each do |h|
+      tc1 = "#{tc.first}#{h[:cat_code].split('.')[1].last}"
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc1}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Validate the asset subtypes for the revenue rolling stock
+
+puts "        team_ali_codes (level 4)"
+
+level_4_rrs = [
+  {:name => 'Bus STD 40 Ft',          :cat_code => 'XX.XX.01'},
+  {:name => 'Bus STD 35 Ft',          :cat_code => 'XX.XX.02'},
+  {:name => 'Bus 30 Ft',              :cat_code => 'XX.XX.03'},
+  {:name => 'Bus < 30 Ft',            :cat_code => 'XX.XX.04'},
+  {:name => 'Bus School',             :cat_code => 'XX.XX.05'},
+  {:name => 'Bus Articulated',        :cat_code => 'XX.XX.06'},
+  {:name => 'Bus Commuter/Suburban',  :cat_code => 'XX.XX.07'},
+  {:name => 'Bus Intercity',          :cat_code => 'XX.XX.08'},
+  {:name => 'Bus Troley STD',         :cat_code => 'XX.XX.09'},
+  {:name => 'Bus Trolley Artic.',     :cat_code => 'XX.XX.10'},
+  {:name => 'Bus Double Deck',        :cat_code => 'XX.XX.11'},
+  {:name => 'Bus Used',               :cat_code => 'XX.XX.12'},
+  {:name => 'Bus School Used',        :cat_code => 'XX.XX.13'},
+  {:name => 'Bus Dual Mode',          :cat_code => 'XX.XX.14'},
+  {:name => 'Van',                    :cat_code => 'XX.XX.15'},
+  {:name => 'Sedan/Station Wagon',    :cat_code => 'XX.XX.16'},
+  {:name => 'Light Rail Car',         :cat_code => 'XX.XX.20'},
+  {:name => 'Heavy Rail Car',         :cat_code => 'XX.XX.21'},
+  {:name => 'Commuter Rail Self Propelled - Elec',  :cat_code => 'XX.XX.22'},
+  {:name => 'Commuter Rail Car Trailer',            :cat_code => 'XX.XX.23'},
+  {:name => 'Commuter Locomotive Disel',            :cat_code => 'XX.XX.24'},
+  {:name => 'Commuter Locomotive Electric',         :cat_code => 'XX.XX.25'},
+  {:name => 'Commuter Rail Cars Used',              :cat_code => 'XX.XX.26'},
+  {:name => 'Commuter Locomotive Used',             :cat_code => 'XX.XX.27'},
+  {:name => 'Commuter Rail Self Prop - Diesel',     :cat_code => 'XX.XX.28'},
+  {:name => 'Cable Car',              :cat_code => 'XX.XX.30'},
+  {:name => 'People Mover',           :cat_code => 'XX.XX.31'},
+  {:name => 'Car, Incline Railway',   :cat_code => 'XX.XX.32'},
+  {:name => 'Ferry Boats',            :cat_code => 'XX.XX.33'},
+  {:name => 'Transferred Vehicle',    :cat_code => 'XX.XX.39'},
+  {:name => 'Spare Parts/ Assoc Capital Main. Items', :cat_code => 'XX.XX.40'}
+]
+
+# Build the fourth level for the revenue rolling stock
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.11.XX XX.12.XX XX.13.XX XX.14.XX XX.15.XX XX.16.XX XX.18.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_4_rrs.each do |h|
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Build the fourth level for the transit way lines
+level_4_twl = [
+  {:name => 'Busway',                     :cat_code => 'XX.XX.01'},
+  {:name => 'Transit Mall',               :cat_code => 'XX.XX.02'},
+  {:name => 'Line Equipment/Struc Misc',  :cat_code => 'XX.XX.03'},
+  {:name => 'Tunnels',                    :cat_code => 'XX.XX.04'},
+  {:name => 'Bridges',                    :cat_code => 'XX.XX.05'},
+  {:name => 'Elevated Structures',        :cat_code => 'XX.XX.06'},
+  {:name => 'People Mover',               :cat_code => 'XX.XX.07'},
+  {:name => 'Miscellaneous Equipment',    :cat_code => 'XX.XX.20'}
+]
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.21.XX XX.22.XX XX.23.XX XX.24.XX XX.26.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_4_twl.each do |h|
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Build the fourth level for the stations/stops/terminals
+level_4_sst = [
+  {:name => 'Terminal, Bus',                  :cat_code => 'XX.XX.01'},
+  {:name => 'Station',                        :cat_code => 'XX.XX.02'},
+  {:name => 'Terminal, Intermodal',           :cat_code => 'XX.XX.03'},
+  {:name => 'Park and Ride Lot',              :cat_code => 'XX.XX.04'},
+  {:name => 'Terminal, Ferry',                :cat_code => 'XX.XX.05'},
+  {:name => 'Fare Collection Equipment',      :cat_code => 'XX.XX.06'},
+  {:name => 'Surveillance/Security Systems',  :cat_code => 'XX.XX.07'},
+  {:name => 'Furniture and Graphics',         :cat_code => 'XX.XX.08'},
+  {:name => 'Route Signing',                  :cat_code => 'XX.XX.09'},
+  {:name => 'Passenger Shelters',             :cat_code => 'XX.XX.10'},
+  {:name => 'Miscellaneous',                  :cat_code => 'XX.XX.20'}
+]
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.31.XX XX.32.XX XX.33.XX XX.34.XX XX.36.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_4_sst.each do |h|
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Build the fourth level for the support facilities and equipment
+level_4_sfe = [
+  {:name => 'Admin Building',           :cat_code => 'XX.XX.01'},
+  {:name => 'Maintenance Facility',     :cat_code => 'XX.XX.02'},
+  {:name => 'Admin/Maint Facility',     :cat_code => 'XX.XX.03'},
+  {:name => 'Storage Facility',         :cat_code => 'XX.XX.04'},
+  {:name => 'Yards and Shops',          :cat_code => 'XX.XX.05'},
+  {:name => 'Shop Equipment',           :cat_code => 'XX.XX.06'},
+  {:name => 'ADP Hardware',             :cat_code => 'XX.XX.07'},
+  {:name => 'ADP Software',             :cat_code => 'XX.XX.08'},
+  {:name => 'Surveillance/Security',    :cat_code => 'XX.XX.09'},
+  {:name => 'Fare Collection (mobile)', :cat_code => 'XX.XX.10'},
+  {:name => 'Support Vehicles',         :cat_code => 'XX.XX.11'},
+  {:name => 'Work Trains',              :cat_code => 'XX.XX.12'},
+  {:name => 'Miscellaneous Equipment',  :cat_code => 'XX.XX.20'},
+  {:name => 'Excl Bicycles Vehicle',    :cat_code => 'XX.XX.40'},
+  {:name => 'Excl Bicycles Equipment',  :cat_code => 'XX.XX.41'},
+  {:name => 'Excl Bicycles Facility',   :cat_code => 'XX.XX.42'},
+  {:name => 'ADA Equipment',            :cat_code => 'XX.XX.43'},
+  {:name => 'CAA Equipment',            :cat_code => 'XX.XX.44'}
+]
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.41.XX XX.42.XX XX.43.XX XX.44.XX XX.46.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_4_sfe.each do |h|
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Build the fourth level for the electrification power distribution
+level_4_epd = [
+  {:name => 'Traction Power',                 :cat_code => 'XX.XX.01'},
+  {:name => 'AC Power Lighting',              :cat_code => 'XX.XX.02'},
+  {:name => 'Power Distributioun Substation', :cat_code => 'XX.XX.03'},
+  {:name => 'Vehicle Locator System',         :cat_code => 'XX.XX.04'},
+  {:name => 'Miscellaneous',                  :cat_code => 'XX.XX.20'}
+]
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.51.XX XX.52.XX XX.53.XX XX.54.XX XX.56.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_4_epd.each do |h|
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Build the fourth level for signal and communications
+level_4_sac = [
+  {:name => 'Train Control/Signal System',  :cat_code => 'XX.XX.01'},
+  {:name => 'Communications Systems',       :cat_code => 'XX.XX.02'},
+  {:name => 'Radios',                       :cat_code => 'XX.XX.03'},
+  {:name => 'Miscellaneous Equipment',      :cat_code => 'XX.XX.20'}
+]
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.61.XX XX.62.XX XX.63.XX XX.64.XX XX.66.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_4_sac.each do |h|
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc}.#{ac1}"
+
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end
+
+# Build the fourth level for transit enhancements
+level_4_enh = [
+  {:name => 'Historic Mass Transp. Bldgs., including Operations', :cat_code => 'XX.XX.01'},
+  {:name => 'Bus Shelters',                                       :cat_code => 'XX.XX.02'},
+  {:name => 'Landscaping/Scenic Beautification',                  :cat_code => 'XX.XX.03'},
+  {:name => 'Public Art',                                         :cat_code => 'XX.XX.04'},
+  {:name => 'Pedestrian Access/Walkways',                         :cat_code => 'XX.XX.05'},
+  {:name => 'Bicycle Access, Facilities, & Equipment on Busses',  :cat_code => 'XX.XX.06'},
+  {:name => 'Transit Connections to Parks',                       :cat_code => 'XX.XX.07'},
+  {:name => 'Signage',                                            :cat_code => 'XX.XX.08'},
+  {:name => 'Enhanced ADA Access',                                :cat_code => 'XX.XX.09'},
+]
+%w{11.XX.XX 12.XX.XX}.each do |top_code|
+  %w{XX.91.XX XX.92.XX XX.93.XX XX.94.XX XX.95.XX}.each do |type_code|
+    pc = top_code.split('.')[0]
+    tc = type_code.split('.')[1]
+    ac = type_code.split('.')[2]
+    parent_code = "#{pc}.#{tc}.#{ac}"
+    parent = TeamAliCode.find_by_code(parent_code)
+
+    level_4_enh.each do |h|
+      ac1 = h[:cat_code].split('.')[2]
+      code = "#{pc}.#{tc}.#{ac1}"
+      
+      row = {name: h[:name], code: code, parent_id: parent.try(:id)}
+      row_does_not_exist = TeamAliCode.find_by(row).nil?
+      row_is_not_unique = TeamAliCode.where(row).count > 1
+      parent_not_found = row[:parent_id].nil?
+
+      row_has_an_unexpected_id = false
+      id_count += 1
+      unless row_does_not_exist || row_is_not_unique
+        row_has_an_unexpected_id = TeamAliCode.find_by(row).id != id_count
+      end
+
+      puts "          #{row.inspect} does not exist in this environment." if row_does_not_exist
+      puts "          #{row.inspect} is not unique in this environment." if row_is_not_unique
+      puts "          #{row.inspect} does not have a parent in this environment. Searched TeamAliCode by code, using: #{parent_code}." if parent_not_found
+      puts "          #{row.inspect} has an unexpected id in this environment. Got #{TeamAliCode.find_by(row).id}. Expected #{id_count}." if row_has_an_unexpected_id
+    end
+  end
+end

--- a/lib/tasks/validate_engine_seeds.rake
+++ b/lib/tasks/validate_engine_seeds.rake
@@ -1,0 +1,165 @@
+# Validates that engine seed data has loaded as expected
+# Should only be called from an app-level validate_engine_seeds rake task
+
+# Copies engine seed data into a temp file
+# Adds the contents of a validation script to the file
+# Runs the complete file to print validation results
+# Then deletes the file
+
+namespace :transam_transit do
+  desc "validate engine seeds"
+  task :validate_engine_seeds, [:app_root] => [:environment] do |t, args|
+
+    # Skip the task unless certain conditions are met
+    puts("  Rake task missing the app_root argument (an absolute path string to the app-level root).") || next unless args[:app_root]
+    puts("  No db/seeds.rb file found for this engine.") || next unless File.exist?(File.join(TransamTransit::Engine.root, "db", "seeds.rb"))
+    puts("  No db/validate_seeds_script.rb file found for this engine.") || next unless File.exist?(File.join(TransamTransit::Engine.root, "db", "validate_seeds_script.rb"))
+
+    # Read the full db/seeds.rb file
+    seeds_file = File.readlines(File.join(TransamTransit::Engine.root, "db", "seeds.rb"))
+
+    # Isolate the data from the creation logic
+
+    # Get table rows
+    data_start_line_nums = []
+    data_end_line_nums = []
+    seeds_file.each.with_index do |line, i|
+      data_start_line_nums << i if line =~ /\w+ += +\[/
+      data_end_line_nums << i if line =~ / *\] *\n/
+    end
+
+    data_line_ranges = []
+    data_start_line_nums.each.with_index do |num, i|
+      data_line_ranges << (num..data_end_line_nums[i])
+    end
+
+    seeds_data = seeds_file.select.with_index do |_line, i|
+      data_line_ranges.any? do |range|
+        range.include?(i)
+      end
+    end
+
+    # Replace 1/0 with true/false for boolean fields
+    # Needed for apps that use postgresql, which won't convert 1/0 implicitly
+    # Will have to be updated by hand
+    seeds_data.each do |line|
+      line.gsub!(/:?active *(=>|:) *1/, ":active => true")
+      line.gsub!(/:?active *(=>|:) *0/, ":active => false")
+      line.gsub!(/:?show_in_nav *(=>|:) *1/, ":show_in_nav => true")
+      line.gsub!(/:?show_in_nav *(=>|:) *0/, ":show_in_nav => false")
+      line.gsub!(/:?show_in_dashboard *(=>|:) *1/, ":show_in_dashboard => true")
+      line.gsub!(/:?show_in_dashboard *(=>|:) *0/, ":show_in_dashboard => false")
+    end
+
+    # Get table names (listed in lookup_tables, replace_tables, merge_tables)
+    add_line = false
+    seeds_file.each do |line|
+      add_line = true if line =~ /\w+_tables += +%w\{/
+      seeds_data << line if add_line == true
+      add_line = false if line =~ /.*\} *\n/
+    end
+
+    # NOTE: this leaves out specially handled tables (like reports)
+    # The validate seeds script should deal with these individually
+
+    # Read the full db/validate_seeds_script.rb file
+    seeds_script = File.readlines(File.join(TransamTransit::Engine.root, "db", "validate_seeds_script.rb"))
+
+    # Read the full db/validate_team_ali_code_seeds_script.rb file
+    # NOTE: We don't get data dynamically from db/team_ali_code_seeds.rb, due to its complexity
+    # So if that file changes, we'll need to update db/validate_team_ali_code_seeds_script.rb by hand
+    team_ali_code_seeds_script = File.readlines(File.join(TransamTransit::Engine.root, "db", "validate_team_ali_code_seeds_script.rb"))
+
+    # === Begin db/seeds/rail.seeds.rb logic ===
+
+    # Only validate if the app-level environment has rail assets configured
+    if Rails.application.config.transam_transit_rail
+
+      # Read the full db/seeds/rail.seeds.rb file
+      rail_seeds_file = File.readlines(File.join(TransamTransit::Engine.root, "db", "seeds", "rail.seeds.rb"))
+
+      # Isolate the data from the creation logic
+
+      # Get table rows
+      data_start_line_nums = []
+      data_end_line_nums = []
+      rail_seeds_file.each.with_index do |line, i|
+        data_start_line_nums << i if line =~ /\w+ += +\[/
+        data_end_line_nums << i if line =~ / *\] *\n/
+      end
+
+      data_line_ranges = []
+      data_start_line_nums.each.with_index do |num, i|
+        data_line_ranges << (num..data_end_line_nums[i])
+      end
+
+      rail_seeds_data = rail_seeds_file.select.with_index do |_line, i|
+        data_line_ranges.any? do |range|
+          range.include?(i)
+        end
+      end
+
+      # Replace 1/0 with true/false for boolean fields
+      # Needed for apps that use postgresql, which won't convert 1/0 implicitly
+      # Will have to be updated by hand
+      rail_seeds_data.each do |line|
+        line.gsub!(/:?active *(=>|:) *1/, ":active => true")
+        line.gsub!(/:?active *(=>|:) *0/, ":active => false")
+        line.gsub!(/:?show_in_nav *(=>|:) *1/, ":show_in_nav => true")
+        line.gsub!(/:?show_in_nav *(=>|:) *0/, ":show_in_nav => false")
+        line.gsub!(/:?show_in_dashboard *(=>|:) *1/, ":show_in_dashboard => true")
+        line.gsub!(/:?show_in_dashboard *(=>|:) *0/, ":show_in_dashboard => false")
+      end
+
+      # NOTE: the tables in db/seeds/rail.seeds.rb are all specially handled
+      # The rails validate seeds script should deal with them individually
+
+      # Read the full db/validate_rail_seeds_script.rb file
+      rail_seeds_script = File.readlines(File.join(TransamTransit::Engine.root, "db", "validate_rail_seeds_script.rb"))
+
+    end
+
+    # === End db/seeds/rail.seeds.rb logic ===
+
+    # Create the temp file validate_seeds_data.rb
+    File.open("validate_seeds_data.rb", "wb") do |f|
+
+      # Add a line to require the app-level rails environment
+      f.write("require \"#{File.join(args[:app_root], "config", "environment.rb")}\"\n")
+
+      # Add the seed data
+      seeds_data.each do |line|
+        f.write(line)
+      end
+
+      # Add the validate seeds script
+      seeds_script.each do |line|
+        f.write(line)
+      end
+
+      # Add the validate team ali code seeds script
+      team_ali_code_seeds_script.each do |line|
+        f.write(line)
+      end
+
+      # Add the rail seed data and script
+      # But only if the app-level environment has rail assets configured
+      if Rails.application.config.transam_transit_rail
+        rail_seeds_data.each do |line|
+          f.write(line)
+        end
+
+        rail_seeds_script.each do |line|
+          f.write(line)
+        end
+      end
+
+    end
+
+    # Run the completed validate_seeds_data.rb file, then delete it
+    if File.exist?("validate_seeds_data.rb")
+      ruby "validate_seeds_data.rb"
+      File.delete("validate_seeds_data.rb")
+    end
+  end
+end


### PR DESCRIPTION
Adds a task to validate that engine seed data has loaded as expected. Should be called from the app level, via `bundle exec rake validate_engine_seeds ENV=env_to_validate`.

Notes:

* file_content_types seed data for transam_transit replaces that for transam_core, but in a way that looks intentional. Left unchanged in both engines. Someone should confirm this is correct.
* asset_subtypes is now a merge table (since it also shows up in transam_sign, and neither engine depends on the other, so we don't know which order they'd load in).
* service_life_calculation_types has different seed data in transam_core, transam_transit, and transam_sign. Someone should check that the interaction between these three is correct.
* fuel_types has different seed data in transam_transit and transam_sign. Someone should check that the interaction between these two is correct.
* vehicle_features has different seed data in transam_transit and transam_sign. Someone should check that the interaction between these two is correct.